### PR TITLE
Scripts added to get rid of common installation error

### DIFF
--- a/docs/Scripts/open5gs_kill.sh
+++ b/docs/Scripts/open5gs_kill.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Get the list of process IDs (PIDs) of processes matching 'open5gs' and remove duplicates
+PIDS=$(sudo netstat -tulpn | grep -E 'open5gs' | awk '{print $7}' | awk -F'/' '{print $1}' | awk '!x[$0]++')
+PID=$(sudo netstat -tulpn | grep -E 'open5gs-sgwud' | awk '{print $6}' | awk -F'/' '{print $1}' | awk '!x[$0]++')
+
+echo "Lisiting all the PID corresponding to open5gs"
+echo $PIDS
+echo $PID
+echo "Kill all the process with above mentioned PID"
+# Loop through each PID and kill the corresponding process
+for P in $PIDS; do
+    kill -9 $P
+done
+
+for P in $PID; do
+    kill -9 $P
+done
+
+echo "All processes matching 'open5gs' have been killed."

--- a/docs/Scripts/tun.sh
+++ b/docs/Scripts/tun.sh
@@ -1,0 +1,4 @@
+sudo ip tuntap add name ogstun mode tun
+sudo ip addr add 10.45.0.1/16 dev ogstun
+sudo ip addr add 2001:db8:cafe::1/48 dev ogstun
+sudo ip link set ogstun up


### PR DESCRIPTION
I have added 2 scripts in folder docs/Scripts namely open5gs_kill.sh and tun.sh.
1) open5gs_kill.sh : Searches already running open5gs process and terminates all such process. Need to install netstat.
2) tun.sh : Creates an TUN interface called ogstun. Thing to note is this tun interface is not persistent hence we may have to run every time we restart the computer.