### PR TITLE
added check_status run_all_srv stop_all_srv

### DIFF
--- a/scripts/check_status.sh
+++ b/scripts/check_status.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+nfs=("open5gs-amfd" "open5gs-ausfd" "open5gs-bsfd" "open5gs-nrfd" "open5gs-nssfd" "open5gs-pcfd" "open5gs-scpd" "open5gs-smfd" "open5gs-upfd" "open5gs-udmd" "open5gs-udrd")
+
+running_count=0
+
+GREEN="\e[32m"
+RED="\e[31m"
+NC="\e[0m"
+
+echo "Status of Open5GS daemons..."
+echo ""
+
+for nf in "${nfs[@]}"; do
+    if ps -e | grep -q "$nf"; then
+        echo -e "${nf#open5gs-}: ${GREEN}running${NC}"
+        ((running_count++))
+    else
+        echo -e "${nf#open5gs-}: ${RED}not running${NC}"
+    fi
+done
+
+echo ""
+echo -e "$running_count NFs are running!"

--- a/scripts/run_all_srv.sh
+++ b/scripts/run_all_srv.sh
@@ -1,0 +1,15 @@
+open5gs-upfd -c upf.yaml &
+open5gs-nrfd -c nrf.yaml &
+open5gs-scpd -c scp.yaml &
+open5gs-scpd -c smf.yaml &
+open5gs-ausfd -c ausf.yaml &
+open5gs-nssfd -c nssf.yaml &
+open5gs-pcfd -c pcf.yaml &
+open5gs-bsfd -c bsf.yaml &
+open5gs-udmd -c udm.yaml &
+open5gs-udrd -c udr.yaml &
+open5gs-amfd -c amf.yaml &
+
+# Retry SMF
+open5gs-smfd -c smf.yaml &
+

--- a/scripts/stop_all_srv.sh
+++ b/scripts/stop_all_srv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pkill -9 open5gs


### PR DESCRIPTION
Added some scripts I frequently used in ~/configurations/basic-configuration/open5gs.
- run_all_srv.sh invokes all 11 open5gs NF daemons in background.
- stop_all_srv.sh stops all 11 open5gs NF daemons running in background.
- check_status.sh checks running status of all 11 open5gs NF daemons in background using ps utility in linux and reports them back in a neat visual manner that simplifies debugging process.

*Note:* I recommend moving these scripts into ~/configurations/basic-configuration/open5gs directory, for easier access, after cloning this repo.